### PR TITLE
Add the minimum amount of dependencies to get the z1 standalone build…

### DIFF
--- a/build_z1.bat
+++ b/build_z1.bat
@@ -1,3 +1,3 @@
 @echo off
 del build\main_z1.sfc
-resources\asar.exe src/z1/standalone.asm build/main_z1.sfc
+resources\asar.exe --symbols=wla --symbols-path=build\main_z1.sym src\z1\standalone.asm build\main_z1.sfc

--- a/src/z1/common.asm
+++ b/src/z1/common.asm
@@ -269,7 +269,7 @@ SnesTransferPatternBlock_Indexed:
     RTS
 
 CheckCaveTransitionOut_common:
-    jsl check_cave_transition_out
+    ; jsl check_cave_transition_out
     jmp $ea2b
 
 print "apu-routines = ", pc

--- a/src/z1/init.asm
+++ b/src/z1/init.asm
@@ -35,7 +35,7 @@ SnesBoot:
     BNE -
 
     SEP #$30
-    jsl UploadItemPalettes
+    ; jsl UploadItemPalettes
     jsl nes_overlay_init
     JML (!BASE_BANK<<16)+$FF76 ; Startup
 

--- a/src/z1/standalone.asm
+++ b/src/z1/standalone.asm
@@ -76,11 +76,14 @@ IsrReset:
 IsrNmi:
     JML [$0811]
 
+;  Non-rom dependencies
+incsrc "../macros.asm"
+incsrc "../defines.asm"
+
 incsrc "labels.asm"
 
 ; Include hooks
 incsrc "hooks.asm"
-
 
 ; Include common code (will be copied to WRAM $1000-$1FFF when switching to M1)
 ; The reason for this is that the main "common" MMC1 bank at $C000-$FFFF is more or less full
@@ -94,9 +97,32 @@ warnpc $A7C000
 org $A88000
 incsrc "init.asm"
 incsrc "snes.asm"
+; Include randomizer additions
+; incsrc "randomizer/main.asm"
+
+; Common NES code/data
+namespace nes
+org $9F8000
+incsrc "../common/nes/overlay.asm"
+warnpc $9FFFFF
+namespace off
 
 ; Include randomizer additions
 org $A99000
 incsrc "../nes-spc/spc.asm"
 org $AFFFFF
 db $00
+
+; namespace mb
+; ; free space for more code here
+; warnpc $FFE000
+
+
+; org $FFE000
+; base $40E000
+; incsrc "../motherbrain/snes.asm"
+; incsrc "../motherbrain/sa1.asm"
+; incsrc "../motherbrain/transition.asm"
+; incsrc "../motherbrain/randomizer/main.asm"
+; print "MotherBrain ends = ", pc
+; namespace off

--- a/src/z3/z3randomizer/LTTP_RND_GeneralBugfixes.asm
+++ b/src/z3/z3randomizer/LTTP_RND_GeneralBugfixes.asm
@@ -297,7 +297,7 @@ incsrc staticrng.asm
 warnpc $AF8401
 ;================================================================================
 org $AF8400
-incsrc tournament.asm
+;incsrc tournament.asm
 incsrc eventdata.asm
 warnpc $B08000
 ;================================================================================


### PR DESCRIPTION
… working.

Overlays do not work which is fine for my purposes. Update build_z1.bat to output wla debug symbols.