### PR TITLE
Fix the bug discovered in testing whereby a very specific $4015 write…

### DIFF
--- a/src/m1/audio/common.asm
+++ b/src/m1/audio/common.asm
@@ -79,7 +79,11 @@ SnesUpdateAudio:
     sta !ApuIo0
 
 .finishedTransfer:
-    stz !ApuWritesIndex
+-   lda !ApuIo0
+    cmp !SpcReadyValue      ; wait until SPC has reached Done and published $7d
+    bne -
+    stz !ApuIo0             ; leave SPC-readable CPU->APU port 0 as fixed benign value
+    stz !ApuWritesIndex     ;  Reset queue
 
 .end
     plp : pla : ply : plx

--- a/src/nes-spc/apu.asm
+++ b/src/nes-spc/apu.asm
@@ -292,18 +292,17 @@ WaitTick:
 cpucheck:
         ; --- Check and process cpu sends
         mov a,$F4
-        cmp	a,$F4
-        bne cpucheck
-
-        cmp a,#$F5              ; wait for port 0 to be $F5 (Reset)
-        bne +
-        call to_reset
-+
         cmp a,#$d7              ; wait for port 0 to be $d7 (CPU ready)    --  this seems to take the bulk of the cycles, which makes sense
         beq apurecv  ;  New cpu data waiting to send
         bra WaitTick
 
 TimerExpired:
+        ;  Check for an spc reset signal
+        mov a, $f4
+        cmp a, #$f5
+        bne +
+        call to_reset
++
         inc TickStepOccurring   ; mark that we've entered an apu step for FrameCounter.Run()
         inc TimerLatchIndex     ; advance pattern index
         mov a, TimerLatchIndex

--- a/src/z1/audio/common.asm
+++ b/src/z1/audio/common.asm
@@ -81,6 +81,10 @@ SnesUpdateAudio:
     sta !ApuIo0           ;  Send packet sequence + first apu index
 
 .finishedTransfer:
+-   lda !ApuIo0
+    cmp !SpcReadyValue      ; wait until SPC has reached Done and published $7d
+    bne -
+    stz !ApuIo0             ; leave SPC-readable CPU->APU port 0 as fixed benign value
     stz !ApuWritesIndex     ;  Reset queue
 
 .end


### PR DESCRIPTION
… at the end of a long sequence of apu frame writes could cause the reset signal $f5 to be persisted in !ApuIo0 and cause the engine to reset.

Moved the reset signal check out of the hot loop and into TimerExpired so it gets handled on the next quarter frame.  This is used during game transition and there's no rush to process it.